### PR TITLE
added a note about how to update Element CLI

### DIFF
--- a/content/references/element-cli.md
+++ b/content/references/element-cli.md
@@ -22,6 +22,8 @@ To install Element CLI, run this command in your terminal:
 npm install -g @volusion/element-cli
 ```
 
+Use the same command above to update your Element CLI to the latest version.
+
 ## Commands
 
 ### Login


### PR DESCRIPTION
Santiago introduced an error message in BTR that instructs developers to update their Element CLI:
https://github.com/Volusion2Dev/zero-BlockThemeRegistry/pull/242

I looked in the docs and they did not mention how to do that.