### PR TITLE
Add instructions to tutorial about Google Account

### DIFF
--- a/content/how-to/env-setup.md
+++ b/content/how-to/env-setup.md
@@ -50,7 +50,7 @@ element login
 
 Then, enter the email address and password for your Volusion account.
 
-If you signed up for your Volusion account using your Google account (using Auth0), you can use the "Forgot Password?" link at [volusion.com/login](https://www.volusion.com/login) to set a password for use with the Element CLI.
+If you signed up for your Volusion account using your Google account, you can use the "Forgot Password?" link at [volusion.com/login](https://www.volusion.com/login) to set a password for use with Element CLI.
 
 ## 7. Get Approved to Develop Blocks
 

--- a/content/how-to/env-setup.md
+++ b/content/how-to/env-setup.md
@@ -50,6 +50,8 @@ element login
 
 Then, enter the email address and password for your Volusion account.
 
+If you signed up for your Volusion account using your Google account (using Auth0), you can use the "Forgot Password?" link at [volusion.com/login](https://www.volusion.com/login) to set a password for use with the Element CLI.
+
 ## 7. Get Approved to Develop Blocks
 
 You need approval from Volusion to begin developing blocks.


### PR DESCRIPTION
 Add instructions about if you signed up with Auth0

Google account users (signed up via Auth0) don't have passwords, but they can create one.

This was a stumbling block I had when signing up.