### PR TITLE
V2E-4275: addScript docs updates

### DIFF
--- a/content/references/block-utils.md
+++ b/content/references/block-utils.md
@@ -13,11 +13,11 @@ In `Block.js` these methods are available via `props` (for example: `props.seo.s
 - **Server Side Only**
   - [addAmpScript](#'addampscript')
   - [addLink](#'addlink')
-  - [addScript](#'addscript')
   - [isAmpRequest](#'isamprequest')
   - [isRendering](#'isrendering')
   - [throwNotFound](#'thrownotfound')
 - **Server and Client Side**
+  - [addScript](#'addscript')
   - [canonicalUrl](#'canonicalurl')
   - [client](#'client')
   - [events](#'events')
@@ -72,6 +72,8 @@ utils.addScript(
   false // optional boolean:  include the async attribute
 )
 ```
+
+NOTE: `async` is set to true by default when calling this from `getDataProps`.
 
 #### 'addScript' Availability
 


### PR DESCRIPTION
Documented:

A. addScript is available on the client (the table of contents was out of date)
B. When called server-side, `async` defaults to true if not provided